### PR TITLE
Meiosis animation uses requestAnimationFrame()

### DIFF
--- a/frameworks/geniverse/lib/burst-core.js
+++ b/frameworks/geniverse/lib/burst-core.js
@@ -23,7 +23,7 @@
   var Burst = function Burst(){
     this.timelines={};
     this.loaded={};
-    this.fps = 30;
+    this.fps = 10;
     this.timelineCount = 0;
     this.onframe=undefined;
   };
@@ -49,12 +49,19 @@
   };
 
   Burst.prototype.play = function(){
-    var deepref = this;
-    // FIXME: Is this correct behavior?
-    window.clearInterval(this.interval);
-    this.interval = window.setInterval(function(){
-      deepref.frame();
-    }, 1000 / this.fps );
+    var _this = this;
+
+    // cf. http://creativejs.com/resources/requestanimationframe/
+    function draw() {
+      _this.timeoutID = setTimeout(function() {
+        _this.requestID = requestAnimationFrame(draw);
+        // Drawing code goes here
+        _this.frame();
+      }, 1000 / this.fps);
+    }
+    // don't start a timer if we've already got one
+    if (!this.timeoutID)
+      draw();
   };
 
   Burst.prototype.frame = function( frame ){
@@ -67,8 +74,14 @@
   };
 
   Burst.prototype.stop = function(){
-    window.clearInterval( this.interval );
-    // FIXME: Removed useless delete statement
+    if (this.requestID) {
+      cancelAnimationFrame(this.requestID);
+      this.requestID = null;
+    }
+    if (this.timeoutID) {
+      clearTimeout(this.timeoutID);
+      this.timeoutID = null;
+    }
   };
 
   // Timeline

--- a/frameworks/geniverse/lib/burst-core.js
+++ b/frameworks/geniverse/lib/burst-core.js
@@ -23,7 +23,7 @@
   var Burst = function Burst(){
     this.timelines={};
     this.loaded={};
-    this.fps = 10;
+    // this.fps = 30;   // no longer used
     this.timelineCount = 0;
     this.onframe=undefined;
   };
@@ -53,14 +53,11 @@
 
     // cf. http://creativejs.com/resources/requestanimationframe/
     function draw() {
-      _this.timeoutID = setTimeout(function() {
-        _this.requestID = requestAnimationFrame(draw);
-        // Drawing code goes here
-        _this.frame();
-      }, 1000 / this.fps);
+      _this.requestID = requestAnimationFrame(draw);
+      _this.frame();
     }
     // don't start a timer if we've already got one
-    if (!this.timeoutID)
+    if (!this.requestID)
       draw();
   };
 
@@ -77,10 +74,6 @@
     if (this.requestID) {
       cancelAnimationFrame(this.requestID);
       this.requestID = null;
-    }
-    if (this.timeoutID) {
-      clearTimeout(this.timeoutID);
-      this.timeoutID = null;
     }
   };
 

--- a/frameworks/geniverse/resources/animation_core.js
+++ b/frameworks/geniverse/resources/animation_core.js
@@ -69,7 +69,8 @@ sc_require('lib/burst-core');
     ////////////////////////////////////////////////////////////////////////////
 
     var self = this,
-        drawLoop, // The variable in which the main draw loop Interval is storred
+        timeoutID,
+        requestID,
         membranes = [],
         chromosomes = [],
         mode = defaultOpts.mode,
@@ -84,6 +85,7 @@ sc_require('lib/burst-core');
         timeline,
         swapui,
         frame = 0,
+        fps = 20,
         maxMembraneOpacity = 0.9,
 
         PI         = Math.PI,
@@ -2139,10 +2141,20 @@ sc_require('lib/burst-core');
     });
   }
 
-    // Set Draw-Loop Interval
+    // Setup Draw-Loop
     ////////////////////////////////////////////////////////////////////////////
-    drawLoop = window.setInterval(function(){ draw(); }, 100);
 
+    // cf. http://creativejs.com/resources/requestanimationframe/
+    function drawLoop() {
+      timeoutID = setTimeout(function() {
+        requestID = requestAnimationFrame(drawLoop);
+        // Drawing code goes here
+        draw();
+      }, 1000 / fps);
+    }
+    // don't start a timer if we've already got one
+    if (!timeoutID)
+      drawLoop();
   };
 
 })(this, this.document, this.jQuery, this.Raphael, Burst);


### PR DESCRIPTION
Attempting to fix [PT #139284509](https://www.pivotaltracker.com/story/show/139284509), "Meiosis runs very slowly and bogs down users". The approach here is to replace the existing `setInterval()`-based animation with a throttled use of `requestAnimationFrame()` as described in [requestAnimationFrame: The secret to silky smooth JavaScript animation!](http://creativejs.com/resources/requestanimationframe/) At the same time I'm also experimenting with dropping the frame rate from 30 fps to 10 fps for the meiosis animation since those chromosomes really aren't moving that fast.

Note that there are two separate throttled `requestAnimationFrame()` loops, the meiosis animation itself, which is triggered by the user pressing the Play button, and one that is running continuously to support the background animation (chromosome jiggling). It would be more efficient to have a single call to `requestAnimationFrame()` that controlled both animations, but that would require a degree of refactoring that doesn't seem warranted at this time.

Note: after review by @sam, I've dropped the throttling of the meiosis animation -- it now runs as fast as requestAnimationFrame() will let it -- and increased the frame rate of the background animation task to 20 fps. In some timing tests I ran on my machine, with one meiosis animation running it averages about ~40ms per rAF call, and with two animations running simultaneously it averages about ~65-70ms per rAF call.