### PR TITLE
Cancel prior animations before starting new animations

### DIFF
--- a/frameworks/geniverse/resources/animation_core.js
+++ b/frameworks/geniverse/resources/animation_core.js
@@ -69,8 +69,6 @@ sc_require('lib/burst-core');
     ////////////////////////////////////////////////////////////////////////////
 
     var self = this,
-        timeoutID,
-        requestID,
         membranes = [],
         chromosomes = [],
         mode = defaultOpts.mode,
@@ -2144,17 +2142,29 @@ sc_require('lib/burst-core');
     // Setup Draw-Loop
     ////////////////////////////////////////////////////////////////////////////
 
+    var $this = $(this);
+
     // cf. http://creativejs.com/resources/requestanimationframe/
     function drawLoop() {
-      timeoutID = setTimeout(function() {
-        requestID = requestAnimationFrame(drawLoop);
+      // use $.data() to store animation IDs with DOM node
+      $this.data('timeoutID', setTimeout(function() {
+        $this.data('requestID', requestAnimationFrame(drawLoop));
         // Drawing code goes here
         draw();
-      }, 1000 / fps);
+      }, 1000 / fps));
     }
-    // don't start a timer if we've already got one
-    if (!timeoutID)
-      drawLoop();
+
+    // cancel any previous animations
+    if ($this.data('requestID')) {
+      cancelAnimationFrame($this.data('requestID'));
+      $this.data('requestID', null);
+    }
+    if ($this.data('timeoutID')) {
+      clearTimeout($this.data('timeoutID'));
+      $this.data('timeoutID', null);
+    }
+
+    drawLoop();
   };
 
 })(this, this.document, this.jQuery, this.Raphael, Burst);


### PR DESCRIPTION
A further attempt to fix [PT #139284509](https://www.pivotaltracker.com/story/show/139284509), "Meiosis runs very slowly and bogs down users". The previous PR on this topic improved the animation performance, but Evangeline still found there to be a degradation of performance over time. Further investigation with additional instrumentation revealed that the code for running the background animation was starting up a new animation loop every time the `retry` button was pressed, without clearing earlier animation loops. With this PR we use jQuery's `$.data()` to store the animation IDs with the node, and then stop any previous animations associated with the node before starting new ones.